### PR TITLE
Quicksort correction

### DIFF
--- a/quicksort.pl
+++ b/quicksort.pl
@@ -1,6 +1,6 @@
 % Implementacja Quicksorta w Prologu
 % Autor korpo, https://github.com/korpo
-
+project_dedalus_quicksort([],[]).
 project_dedalus_quicksort([X],[X]).
 project_dedalus_quicksort([X|Xs],Ys) :-
   project_dedalus_quicksort_helper_partition(Xs,X,Left,Right),


### PR DESCRIPTION
According to all known laws of aviation, there is no way that a bee should be able to fly. Its wings are too small to get its fat little body off the ground. The bee, of course, flies anyways. Because bees don't care what humans think is impossible.