### PR TITLE
Dodany warunek brzegowy, dla pustych tablic

### DIFF
--- a/quicksort.pl
+++ b/quicksort.pl
@@ -1,6 +1,8 @@
 % Implementacja Quicksorta w Prologu
 % Autor korpo, https://github.com/korpo
 
+
+project_dedalus_quicksort([],[]).
 project_dedalus_quicksort([X],[X]).
 project_dedalus_quicksort([X|Xs],Ys) :-
   project_dedalus_quicksort_helper_partition(Xs,X,Left,Right),
@@ -8,10 +10,10 @@ project_dedalus_quicksort([X|Xs],Ys) :-
   project_dedalus_quicksort(Right,Rs),
   append(Ls,[X|Rs],Ys).
 
-project_dedalus_quicksort_helper_partition([X|Xs],Y,[X|Ls],Rs) :- 
-  X =< Y, 
+project_dedalus_quicksort_helper_partition([X|Xs],Y,[X|Ls],Rs) :-
+  X =< Y,
   project_dedalus_quicksort_helper_partition(Xs,Y,Ls,Rs).
-project_dedalus_quicksort_helper_partition([X|Xs],Y,Ls,[X|Rs]) :- 
-  X  > Y, 
+project_dedalus_quicksort_helper_partition([X|Xs],Y,Ls,[X|Rs]) :-
+  X  > Y,
   project_dedalus_quicksort_helper_partition(Xs,Y,Ls,Rs).
 project_dedalus_quicksort_helper_partition([],_,[],[]).


### PR DESCRIPTION
Bez warunku brzegowego quicksort nie mógł działać, dlatego należało go dodać